### PR TITLE
Update pyproject.toml to use poetry 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Faker = "^15.1.3"
 pytest = "^7.2.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0,<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
This change prevents target-postgres from trying to build with poetry 2 which was released on 2025-01-05.